### PR TITLE
Added a fix for mysql service fail

### DIFF
--- a/challenge/start.sh
+++ b/challenge/start.sh
@@ -1,5 +1,8 @@
 #!/bin/bash
 
+# Fix for mysql service
+chown -R mysql:mysql /var/lib/mysql
+
 # Start mysql service
 service mysql start
 


### PR DESCRIPTION
The command `service mysql start` was resulting in:
```
[FAIL] Starting MySQL database server: mysqld . . . . . . . . . . . . . . failed
```
I had to add `chown -R mysql:mysql /var/lib/mysql` to the script in order to start the mysql service in the container.